### PR TITLE
[ADD]New method added to validate orders manually by operator when op…

### DIFF
--- a/custom_addons/custom_odooship_decanting_process/views/stock_picking_inherit_views.xml
+++ b/custom_addons/custom_odooship_decanting_process/views/stock_picking_inherit_views.xml
@@ -25,6 +25,19 @@
                             string="Pack"
                             type="object"
                             class="btn-primary"/>
+                    <button name="button_validate_picking"
+                            string="Validate Order"
+                            type="object"
+                            class="btn-primary"
+                            invisible="state in ('done', 'cancel')"
+                    />
+                </xpath>
+                <!-- Hide  Validate button -->
+                <xpath expr="//form/header/button[@name='button_validate']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//form/header/button[@class='o_btn_validate']" position="attributes">
+                    <attribute name="invisible">1</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
…erator clicks this button it will send all the information of receipt to api/discrepency_receiver and hiden validate button from view

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
